### PR TITLE
Backups improvements

### DIFF
--- a/docs/features/backups.md
+++ b/docs/features/backups.md
@@ -9,7 +9,7 @@ Our backup system is designed to provide:
 * **Data Consistency:**  Our backup process guarantees data consistency, ensuring you can reliably restore to any point in time.
 * **Low RPO:** Incremental backups contribute to a low Recovery Point Objective (RPO), meaning minimal data loss in case of a failure.
 
-**Backup Configuration and Schedule:**
+## Backup Configuration and Schedule
 
 The frequency and retention period of your backups depend on the tier you choose. For example, in a free tier
 we take backups every 6 hours and store them for 3 days. Whereas for production workloads, we backups are stored every

--- a/docs/features/backups.md
+++ b/docs/features/backups.md
@@ -12,7 +12,7 @@ Our backup system is designed to provide:
 ## Backup Configuration and Schedule
 
 The frequency and retention period of your backups depend on the tier you choose. For example, in a free tier
-we take backups every 6 hours and store them for 3 days. Whereas for production workloads, we backups are stored every
+we take backups every 6 hours and store them for 3 days. Whereas for production workloads, backups are stored every
 5 minutes and kept for 30 days.
 
 This means that in the unlikely event of data loss, you can quickly restore your database to a recent state,

--- a/docs/features/backups.md
+++ b/docs/features/backups.md
@@ -1,19 +1,19 @@
 # Backups
 
-Ivee automatically backs up your instances to ensure data safety and business continuity. 
+Ivee automatically backs up your instances to ensure data safety and business continuity.
 Our backup system is designed to provide:
 
 * **Automated Backups:** We take care of your backups, so you don't have to.  No manual intervention is required.
 * **Incremental Backups:**  Ivee utilizes incremental backups, capturing only the changes made since the last backup.
-* This minimizes storage space and backup time, which lowers your cloud bill even further in [Bring Your Own Account mode](../deploy/mode-byoa.md).
+    * This minimizes storage space and backup time, which lowers your cloud bill even further in [Bring Your Own Account mode](../deploy/mode-byoa.md).
 * **Data Consistency:**  Our backup process guarantees data consistency, ensuring you can reliably restore to any point in time.
 * **Low RPO:** Incremental backups contribute to a low Recovery Point Objective (RPO), meaning minimal data loss in case of a failure.
 
 **Backup Configuration and Schedule:**
 
-The frequency and retention period of your backups depend on the tier you choose. For example, in a free tier 
-we take backups every 6 hours and store them for 3 days. Whereas for production workloads, we backups are stored every 
+The frequency and retention period of your backups depend on the tier you choose. For example, in a free tier
+we take backups every 6 hours and store them for 3 days. Whereas for production workloads, we backups are stored every
 5 minutes and kept for 30 days.
 
-This means that in the unlikely event of data loss, you can quickly restore your database to a recent state, 
+This means that in the unlikely event of data loss, you can quickly restore your database to a recent state,
 minimizing downtime and impact on your applications.


### PR DESCRIPTION
This PR addresses 3 issues:

**1.** Indentation 

As it was:

<img width="773" alt="was" src="https://github.com/user-attachments/assets/953b84b4-6828-4243-a547-0f32094887e5">

as it is now:

<img width="760" alt="now" src="https://github.com/user-attachments/assets/42468d0c-c65a-4dc9-a2b6-d596b4657e2a">

**2.** Makes "Backup Configuration and Schedule" a subsection, for consistency and for easy reference (so a link to this section can be copied and pasted)

**3.** Fixes a statement, by removing "we"

Thanks,